### PR TITLE
Removing unused topic from subnav.

### DIFF
--- a/master_middleman/source/subnavs/mulesoft_subnav.erb
+++ b/master_middleman/source/subnavs/mulesoft_subnav.erb
@@ -15,10 +15,6 @@
       <li>
         <a href="/partners/mulesoft/configuring.html">Configuring Anypoint Platform for PCF</a>
       </li>
-      
-      <li>
-        <a href="/partners/mulesoft/using.html">Using Anypoint Platform for PCF</a>
-      </li>
 
       <li>
         <a href="/partners/mulesoft/release-notes.html">Anypoint Platform for PCF Release Notes</a>


### PR DESCRIPTION
Hi all,

This PR removes a link in the subnav to a topic that I am removing from the docs-mulesoft-anypoint repo. I will submit that PR today. However, we should not merge either PR until the 1.5.2 version of the tile releases. Marina can confirm, but this will probably be next week.

Also, ignore the fact that this is in a branch called 1.5.1. I didn't create a new branch for this change.

Let me know if you have any questions.

Thanks in advance!!!!

-Steven